### PR TITLE
Implement Fire Spread Visualization in MainScene

### DIFF
--- a/src/components/FireSpread.js
+++ b/src/components/FireSpread.js
@@ -1,4 +1,3 @@
-import weather from "./Weather.js";
 import { technique } from './DeploymentClickEvents.js'
 
 /**

--- a/src/components/FireSpread.js
+++ b/src/components/FireSpread.js
@@ -58,6 +58,7 @@ class FireSpread {
             for (let x = 0; x < this.map.width; x++) {
                 const tile = this.map.grid[y][x];
                 if (tile.burnStatus === "burning") {
+                    console.log(`Processing burning tile at (${x}, ${y})`);
                     spreadCount += this.processBurningTile(tile, newGrid, x, y);
                 }
             }

--- a/src/scenes/mainScene.js
+++ b/src/scenes/mainScene.js
@@ -4,10 +4,10 @@
  * Includes HUD creation, procedural map generation, and interactive terrain rendering.
  */
 
-// Import necessary modules and functions
 import Map from '../components/MapGenerator.js';
-import { createHUD, preloadHUD } from '../components/ui.js'; // Import functions from your ui.js
-import { lightFire } from "../components/FireSpread.js";
+import { createHUD, preloadHUD } from '../components/ui.js';
+import FireSpread, { lightFire } from "../components/FireSpread.js";
+import Weather from "../components/Weather.js";
 
 /**
  * Represents the main gameplay scene in the Sim Firefighter game.
@@ -66,9 +66,18 @@ class MainScene extends Phaser.Scene {
         this.map.bsp.getPartitions().forEach((partition, index) => {
             console.log(`Partition ${index}: x=${partition.x}, y=${partition.y}, width=${partition.width}, height=${partition.height}`);
         });
+        const weather = new Weather(15, 40, 30); // temperature: 15°F, humidity: 40%, windSpeed: 30 mph
+
+        this.fireSpread = new FireSpread(this.map, weather);
 
         // Render the Map
         this.renderMap(this.map, tileSize);
+
+        // Start a fire at a 'random' tile
+        this.startFire();
+
+        // Initialize Fire Spread Logic
+        this.startFireSpreadSimulation();
 
         console.log("MainScene Create Finished");
     }
@@ -89,6 +98,8 @@ class MainScene extends Phaser.Scene {
                 // Determine terrain asset key
                 const terrainKey = this.textures.exists(tile.terrain) ? tile.terrain : 'defaultTerrain';
 
+                console.log(`Rendering tile at (${x}, ${y}) with terrain ${tile.terrain}, using sprite key: ${terrainKey}`);
+
                 // Add sprite for each terrain type
                 const sprite = this.add.sprite(
                     startX + x * tileSize,
@@ -96,25 +107,59 @@ class MainScene extends Phaser.Scene {
                     terrainKey
                 ).setOrigin(0).setScale(0.5, 0.5);
 
+                // Store sprite reference in the tile object
+                tile.sprite = sprite;
+
+                // Debugging: Log the sprite after it's created
+                console.log(`Created sprite for tile at (${x}, ${y}) with sprite reference:`, sprite);
+
                 // Make the tile interactive
                 sprite.setInteractive();
 
-                // Light flammable terrain on fire
-                if (tile.terrain === "shrub") {
-                    lightFire(this, sprite);
-                }
-
                 // Add click interaction for each tile
                 sprite.on('pointerdown', () => {
-                    if (tile.terrain === "shrub") {
-                        console.log(`Lighting shrub on fire at (${x}, ${y})`);
-                    } else {
-                        console.log(`Clicked on ${tile.terrain} at (${x}, ${y}) - no action taken.`);
-                    }
+                    console.log(`Clicked on ${tile.terrain} at (${x}, ${y})`);
                 });
             });
         });
     }
+
+    // Function to randomly start a fire on the map
+    startFire() {
+        // Randomly select a starting tile
+        const startX = Math.floor(Math.random() * this.map.width);
+        const startY = Math.floor(Math.random() * this.map.height);
+
+        // Set the selected tile's burnStatus to "burning"
+        this.map.grid[startY][startX].burnStatus = "burning";
+        console.log(`Starting fire at (${startX}, ${startY})`);
+
+    }
+
+    startFireSpreadSimulation() {
+        this.time.addEvent({
+            delay: 1000,
+            callback: () => {
+                console.log("Simulating fire step...");
+                this.fireSpread.simulateFireStep();
+
+                // Iterate over the tiles after each simulation step and light the fire
+                for (let y = 0; y < this.map.height; y++) {
+                    for (let x = 0; x < this.map.width; x++) {
+                        const tile = this.map.grid[y][x];
+                        if (tile.burnStatus === "burning" && !tile.fireSprite) {
+                            const tileSprite = tile.sprite; // Get the sprite for the tile
+                            lightFire(this, tileSprite); // Call lightFire
+                            tile.fireSprite = true; // Mark that fire has been lit for this tile
+                        }
+                    }
+                }
+            },
+            repeat: 16  // Will run 10 times, then stop
+        });
+    }
+
+
 }
 
 export default MainScene;

--- a/src/scenes/mainScene.js
+++ b/src/scenes/mainScene.js
@@ -9,6 +9,7 @@ import { createHUD, preloadHUD } from '../components/ui.js';
 import FireSpread, { lightFire } from "../components/FireSpread.js";
 import Weather from "../components/Weather.js";
 
+
 /**
  * Represents the main gameplay scene in the Sim Firefighter game.
  */
@@ -36,6 +37,7 @@ class MainScene extends Phaser.Scene {
         this.load.image('shrub', 'assets/64x64-Map-Tiles/Shrubs/shrubs-on-sand.png');
         this.load.image('tree', 'assets/64x64-Map-Tiles/Trees/trees-on-light-dirt.png');
     }
+
 
     /**
      * Sets up the scene, including HUD creation and procedural map generation.
@@ -82,6 +84,7 @@ class MainScene extends Phaser.Scene {
         console.log("MainScene Create Finished");
     }
 
+
     /**
      * Renders the map tiles onto the scene.
      * @param {Map} map - The procedural map instance to render.
@@ -98,8 +101,6 @@ class MainScene extends Phaser.Scene {
                 // Determine terrain asset key
                 const terrainKey = this.textures.exists(tile.terrain) ? tile.terrain : 'defaultTerrain';
 
-                console.log(`Rendering tile at (${x}, ${y}) with terrain ${tile.terrain}, using sprite key: ${terrainKey}`);
-
                 // Add sprite for each terrain type
                 const sprite = this.add.sprite(
                     startX + x * tileSize,
@@ -109,9 +110,6 @@ class MainScene extends Phaser.Scene {
 
                 // Store sprite reference in the tile object
                 tile.sprite = sprite;
-
-                // Debugging: Log the sprite after it's created
-                console.log(`Created sprite for tile at (${x}, ${y}) with sprite reference:`, sprite);
 
                 // Make the tile interactive
                 sprite.setInteractive();
@@ -124,21 +122,45 @@ class MainScene extends Phaser.Scene {
         });
     }
 
-    // Function to randomly start a fire on the map
+
+    /**
+     * Starts a fire at a random tile on the map by setting its burnStatus to "burning"
+     * and visually representing it with the fire sprite.
+     * Assumes `this.map` has `width`, `height`, and a 2D `grid` array with `burnStatus`.
+     * Logs the fire's starting location to the console.
+     */
     startFire() {
         // Randomly select a starting tile
         const startX = Math.floor(Math.random() * this.map.width);
         const startY = Math.floor(Math.random() * this.map.height);
 
         // Set the selected tile's burnStatus to "burning"
-        this.map.grid[startY][startX].burnStatus = "burning";
+        const tile = this.map.grid[startY][startX];
+        tile.burnStatus = "burning";
         console.log(`Starting fire at (${startX}, ${startY})`);
 
+        // Ensure the fire sprite is added to the tile when fire starts
+        if (tile.sprite) {
+            lightFire(this, tile.sprite);
+            tile.fireSprite = true; // Mark that fire has been visually applied
+        }
     }
 
+
+
+    /**
+     * Starts a fire spread simulation that runs periodically, updating the fire's state on the map.
+     *
+     * - Runs every 2 seconds (`delay: 2000`) for 10 iterations (`repeat: 10`).
+     * - Invokes `this.fireSpread.simulateFireStep()` to compute fire progression.
+     * - Iterates through the map's grid to visually update tiles marked as "burning".
+     * - Calls `lightFire(this, tile.sprite)` to apply fire visuals and marks the tile as processed.
+     *
+     * Assumes `this.map.grid` contains tiles with `burnStatus`, `sprite`, and `fireSprite` properties.
+     */
     startFireSpreadSimulation() {
         this.time.addEvent({
-            delay: 1000,
+            delay: 2000,
             callback: () => {
                 console.log("Simulating fire step...");
                 this.fireSpread.simulateFireStep();
@@ -155,9 +177,10 @@ class MainScene extends Phaser.Scene {
                     }
                 }
             },
-            repeat: 16  // Will run 10 times, then stop
+            repeat: 10 // Will run 10 times, then stop
         });
     }
+
 
 
 }


### PR DESCRIPTION
This PR introduces the implementation of fire spread visualization within the MainScene, allowing the fire simulation to be accurately displayed on the procedural map. The following changes have been made to ensure the fire spread algorithm is both functional and visually represented:

### Key Changes:
**Fire Spread Simulation Integration:**

- Added startFireSpreadSimulation() to periodically simulate fire spread across the map.

- Ensured fire updates visually by checking tile burn status and applying fire sprites accordingly.

**Fire Initialization Logic:**

- Implemented startFire() to randomly ignite a tile on the map and apply the appropriate fire sprite.

- Fixed an issue where grass tiles were not displaying fire sprites correctly by ensuring lightFire() is used.

**Sprite Rendering Improvements:**

- Modified renderMap() to properly assign terrain sprites and make them interactive with the changes due to the fire spreading. 
- Added logic to track sprite references and ensure correct visualization during updates.

**Performance Considerations:**

- Added a controlled simulation loop to update fire progression at defined intervals to balance performance.
- Ensured the fire simulation doesn't overwhelm the gameboard by limiting repetitions.

**Fixes & Enhancements:**

- Addressed a bug where fire animations were not appearing on certain terrain types like grass.
- Ensured that fire sprites do not duplicate by tracking fireSprite status within each tile.
- Improved debugging outputs for fire spread and partition logging.
**How to Test:**

- Run the game and observe the procedural map generation.
- Verify that a random tile ignites and spreads fire over time.
- Click on burning tiles to interact and confirm visual updates.
- Ensure fire animation behaves correctly across different terrain types.
