### PR TITLE
Extinguished Tiles 

### DIFF
--- a/src/components/DeploymentClickEvents.js
+++ b/src/components/DeploymentClickEvents.js
@@ -123,41 +123,14 @@ export function show_notification (scene, notification) {
      });
 }
 
-// Assuming you already have this method for handling tile clicks
-function handleFireExtinguish(fireSprite) {
-    // Convert fire sprite position to tile coordinates using the same method as handleTileClick
-    const startX = (this.cameras.main.width - this.map.width * this.tileSize) / 2;
-    const startY = (this.cameras.main.height - this.map.height * this.tileSize) / 2;
-
-    let tileX = Math.floor((fireSprite.x - startX) / this.tileSize);
-    let tileY = Math.floor((fireSprite.y - startY) / this.tileSize);
-
-    console.warn(`Fire at tile coordinates: (${tileX}, ${tileY})`);
-
-    // Ensure the tile is within bounds
-    if (tileX >= 0 && tileX < this.map.width && tileY >= 0 && tileY < this.map.height) {
-        let clickedTile = this.map.getTile(tileX, tileY);
-        console.log(clickedTile ? `Tile found: ${clickedTile.toString()}` : "No tile found at this position!");
-
-        // If tile exists, update its burn status
-        if (clickedTile) {
-            clickedTile.burnStatus = 'extinguished';
-            console.log(`Tile at (${tileX}, ${tileY}) burn status updated to: ${clickedTile.burnStatus}`);
-        }
-    }
-}
-
-
 // This function allows the player to deploy an asset
 export function use_resource (scene, x, y, fireSprite) {
-
     // Create an object that controls deployment graphics
     let asset = new AnimatedSprite(3);
 
     // Deploy animations
     if (activated_resource === "hose") {
         if (getHose() > 0) {
-            // Start timer
             if (cooldown[0] == 0) {
                 setHose(-1);
                 asset.useHose(scene, x, y, fireSprite);
@@ -169,7 +142,7 @@ export function use_resource (scene, x, y, fireSprite) {
             }
 
             scene.time.delayedCall(t_hose, () => {
-                handleFireExtinguish.call(scene, fireSprite)
+                scene.events.emit('extinguishFire', fireSprite);
                 bank.setText(`${coins}`);
             })
         } else {
@@ -181,7 +154,6 @@ export function use_resource (scene, x, y, fireSprite) {
     }
     if (activated_resource === "extinguisher") {
         if (getExtinguisher() > 0) {
-            // Start timer
             if (cooldown[1] == 0) {
                 setExtinguisher(-1);
                 asset.useFireExtinguisher(scene, x, y, fireSprite);
@@ -201,7 +173,6 @@ export function use_resource (scene, x, y, fireSprite) {
     }
     if (activated_resource === "helicopter") {
         if (getHelicopter() > 0) {
-            // Start timer
             if (cooldown[2] == 0) {
                 setHelicopter(-1);
                 asset.useHelicopter(scene, x, y, fireSprite);
@@ -212,7 +183,7 @@ export function use_resource (scene, x, y, fireSprite) {
             }
 
             scene.time.delayedCall(t_helicopter, () => {
-                handleFireExtinguish.call(scene, fireSprite)
+                scene.events.emit('extinguishFire', fireSprite);
                 bank.setText(`${coins}`);
             })
             
@@ -225,7 +196,6 @@ export function use_resource (scene, x, y, fireSprite) {
     }
     if (activated_resource === "firetruck") {
         if (getFiretruck() > 0) {
-            // Start timer
             if (cooldown[3] == 0) {
                 setFiretruck(-1);
                 asset.useFiretruck(scene, x, y, fireSprite);
@@ -236,7 +206,7 @@ export function use_resource (scene, x, y, fireSprite) {
             }
 
             scene.time.delayedCall(t_firetruck, () => {
-                handleFireExtinguish.call(scene, fireSprite)
+                scene.events.emit('extinguishFire', fireSprite);
                 bank.setText(`${coins}`);
             })
 
@@ -249,7 +219,6 @@ export function use_resource (scene, x, y, fireSprite) {
     }
     if (activated_resource === "airtanker") {
         if (getAirtanker() > 0) {
-            // Start timer
             if (cooldown[4] == 0) {
                 setAirtanker(-1);
                 asset.useAirtanker(scene, x, y, fireSprite);
@@ -260,7 +229,7 @@ export function use_resource (scene, x, y, fireSprite) {
             }
 
             scene.time.delayedCall(t_airtanker, () => {
-                handleFireExtinguish.call(scene, fireSprite)
+                scene.events.emit('extinguishFire', fireSprite);
                 bank.setText(`${coins}`);
             })
 
@@ -273,7 +242,6 @@ export function use_resource (scene, x, y, fireSprite) {
     }
     if (activated_resource === "hotshot-crew") {
         if (getHotshotCrew() > 0) {
-            // Start timer
             if (cooldown[5] == 0) {
                 setHotshotCrew(-1);
                 asset.useHotshotCrew(scene, x, y, fireSprite);
@@ -284,7 +252,7 @@ export function use_resource (scene, x, y, fireSprite) {
             }
 
             scene.time.delayedCall(t_hotshotcrew, () => {
-                handleFireExtinguish.call(scene, fireSprite)
+                scene.events.emit('extinguishFire', fireSprite);
                 bank.setText(`${coins}`);
             })
 
@@ -297,7 +265,6 @@ export function use_resource (scene, x, y, fireSprite) {
     }
     if (activated_resource === "smokejumper") {
         if (getSmokejumpers() > 0) {
-            // Start timer
             if (cooldown[6] == 0) {
                 setSmokejumpers(-1);
                 asset.useSmokejumpers(scene, x, y, fireSprite);
@@ -308,7 +275,7 @@ export function use_resource (scene, x, y, fireSprite) {
             }
 
             scene.time.delayedCall(t_smokejumpers_plane + t_smokejumpers_ground, () => {
-                handleFireExtinguish.call(scene, fireSprite)
+                scene.events.emit('extinguishFire', fireSprite);
                 bank.setText(`${coins}`);
             })
 

--- a/src/components/FireSpread.js
+++ b/src/components/FireSpread.js
@@ -65,20 +65,17 @@ class FireSpread {
 
 
     /**
-     * Updates the sprite of a tile to reflect its burnt status.
-     * 
-     * This method checks if the specified tile has a sprite and, if so, replaces the sprite's texture 
-     * with the corresponding texture for the burnt version of the tile's terrain.
+     * Updates the sprite of a tile to reflect its current status (burnt or extinguished).
      * 
      * @param {number} x - The x-coordinate of the tile to update.
      * @param {number} y - The y-coordinate of the tile to update.
      * @returns {void} This method does not return any value. It updates the sprite of the specified tile.
      */
-    updateBurntTileSprite(tileOrX, y) {
+    updateSprite(tileOrX, y) {
         let tile;
         
         // Support both calling patterns:
-        // updateBurntTileSprite(tile) or updateBurntTileSprite(x, y)
+        // updateSprite(tile) or updateSprite(x, y)
         if (typeof tileOrX === 'object') {
             // Called with a tile object
             tile = tileOrX;
@@ -89,7 +86,7 @@ class FireSpread {
                 tile = this.map.grid[y][tileOrX];
             } else {
                 // Invalid coordinates
-                console.warn("FireSpread: Invalid coordinates for updateBurntTileSprite");
+                console.warn("FireSpread: Invalid coordinates for updateSprite");
                 return;
             }
         }
@@ -97,7 +94,7 @@ class FireSpread {
         // Check if the tile, its sprite, and the sprite's scene are all valid
         if (tile && tile.sprite && tile.sprite.scene && tile.sprite.scene.sys) {
             try {
-                // Set the texture to the burnt version
+                // Set the texture based on the current terrain type
                 tile.sprite.setTexture(tile.terrain);
             } catch (error) {
                 console.warn("FireSpread: Error updating tile sprite texture", error);
@@ -134,7 +131,6 @@ class FireSpread {
     
             // Check if the tile has a fire sprite and extinguish it
             if (tile.fireS) {
-                // Remove fire sprite
                 setTimeout(() => { 
                     tile.fireS.extinguishFire(); 
                     
@@ -148,14 +144,14 @@ class FireSpread {
                     }
             
                     // Update the tile's sprite to show it burned
-                    this.updateBurntTileSprite(x, y);
+                    this.updateSprite(x, y);
             
                 }, 2000); // 2 second delay
             }
             
     
             // Call function to update tile sprite
-            this.updateBurntTileSprite(x, y);
+            this.updateSprite(x, y);
         }
         return spreadCount;
     }


### PR DESCRIPTION
### Extinguished Tile Sprites & Status

- Moved handleFireExtinguish from DeploymentClickEvents to Mapscene since it handles tile position logic
- Now, DeploymentClickEvents simply emits calls to the scene
- Tiles' burn status properly is set to extinguished upon successful asset deployment, and consequently updates to its extinguished terrain
- FireSpread's updateBurntTileSprite method was refactored and imported into MapScene as updateSprite, so it can reset a tile's terrain once it has burnt our or been extinguished 