### PR TITLE
Bug Fix: Added Asset Deselection

### DIFF
--- a/src/components/DeploymentClickEvents.js
+++ b/src/components/DeploymentClickEvents.js
@@ -6,8 +6,7 @@ import { getHose, setHose, getExtinguisher, setExtinguisher, getHelicopter, setH
 // Global vars to track which technique is currently active and whether their cooldown is active
 export let technique = "";
 export let activated_resource = "none";
-
-export let dropDirection = 'horizontal'; // default
+export let mode = "cursor";
 
 // Global cooldown variable
 // --> This is an array where each index represents an asset, in the following order:
@@ -82,23 +81,36 @@ export function activate_resource (index, resource, resourceName, ONcursorURL, O
     console.log(`Resource Activated: ${resourceName}`)
     resource.setInteractive();
 
-    let active = true;
-
     // When water hose is clicked (activated), the cursor is replaced with water and fire sprites can be destroyed.
     // When water hose is deactivated, fire sprites can no longer be destroyed.
     resource.on(
         "pointerdown",
         function (pointer, localX, localY, event) {
-            if (active === true) {
-                // Check for already-activated resources
-                deactivate(all_assets);
-
+            // Activates a resource on click if none are active
+            if (activated_resource === "none") {
                 resource.setTexture('active-' + resourceName +'');
                 scene.input.setDefaultCursor('url('+ ONcursorURL +'), pointer');
                 technique = techniqueNameON;
                 activated_resource = `${resourceName}`;
-                
-            } 
+                mode = "deployment";
+            } else {
+                // Deactive clicked asset if it's already active
+                if (activated_resource === resourceName) {
+                    deactivate(all_assets);
+                    resource.setTexture(resourceName);
+                    technique = techniqueNameOFF;
+                    scene.input.setDefaultCursor('url('+ OFFcursorURL +'), pointer');
+                    activated_resource == "none";
+                    mode = "cursor";
+                } else { // Deactivate old asset and activate new asset if a different one is clicked
+                    deactivate(all_assets);
+                    resource.setTexture('active-' + resourceName +'');
+                    scene.input.setDefaultCursor('url('+ ONcursorURL +'), pointer');
+                    technique = techniqueNameON;
+                    activated_resource = `${resourceName}`;
+                    mode = "deployment";
+                }
+            }
         },
         this
     );
@@ -180,55 +192,27 @@ export function use_resource (scene, x, y, fireSprite) {
     }
     if (activated_resource === "helicopter") {
         if (getHelicopter() > 0) {
-          if (cooldown[2] === 0) {
-            setHelicopter(-1);
-            asset.useHelicopter(scene, x, y, fireSprite);
-            asset.startTimer(2, scene, c_helicopter, 750, 210);
-            coins += 300;
-          } else {
-            show_notification(scene, n_cooldown);
-          }
-      
-          // ==== CROSS‑SHAPED DROP: center + N, S, E, W ====
-          scene.time.delayedCall(t_helicopter, () => {
-            const mapScene = scene.scene.get('MapScene');
-            const size    = mapScene.TILE_SIZE;
-            const tileX   = Math.floor(fireSprite.x / size);
-            const tileY   = Math.floor(fireSprite.y / size);
-      
-            // offsets: center, north, south, east, west
-            const deltas = [
-              [ 0,  0],  // center
-              [ 0, -1],  // north
-              [ 0,  1],  // south
-              [ 1,  0],  // east
-              [-1,  0],  // west
-            ];
-      
-            deltas.forEach(([dx, dy]) => {
-              const nx = tileX + dx;
-              const ny = tileY + dy;
-              if (
-                nx >= 0 && nx < mapScene.map.width &&
-                ny >= 0 && ny < mapScene.map.height
-              ) {
-                const neighbor = mapScene.map.grid[ny][nx];
-                if (neighbor && neighbor.sprite) {
-                  mapScene.events.emit('extinguishFire', neighbor.sprite);
-                }
-              }
-            });
-      
-            bank.setText(`${coins}`);
-          });
-          // =============================================
-      
+            if (cooldown[2] == 0) {
+                setHelicopter(-1);
+                asset.useHelicopter(scene, x, y, fireSprite);
+                asset.startTimer(2, scene, c_helicopter, 750, 210);
+                coins += 300;
+            } else {
+                show_notification(scene, n_cooldown);
+            }
+
+            scene.time.delayedCall(t_helicopter, () => {
+                scene.events.emit('extinguishFire', fireSprite);
+                bank.setText(`${coins}`);
+            })
+            
         } else {
-          console.log("Sorry! You ran out!");
-          show_notification(scene, out_helicopters);
+            console.log("Sorry! You ran out!");
+
+            // Notification to player that they are out of helicopters
+            show_notification(scene, out_helicopters);
         }
-      }
-      
+    }
     if (activated_resource === "firetruck") {
         if (getFiretruck() > 0) {
             if (cooldown[3] == 0) {
@@ -252,96 +236,52 @@ export function use_resource (scene, x, y, fireSprite) {
             show_notification(scene, out_firetrucks);
         }
     }
-
     if (activated_resource === "airtanker") {
         if (getAirtanker() > 0) {
-        if (cooldown[4] == 0) {
-            setAirtanker(-1);
-            asset.useAirtanker(scene, x, y, fireSprite);
-            asset.startTimer(4, scene, c_airtanker, 750, 370);
-            coins += 500;
-        } else {
-            show_notification(scene, n_cooldown);
-        }
-    
-        // === REPLACED SINGLE‑TILE EXTINCTION WITH A 5‑TILE LOOP ===
-        scene.time.delayedCall(t_airtanker, () => {
-            // grab the MapScene so we can index into its grid
-            const mapScene = scene.scene.get('MapScene');
-            const size    = mapScene.TILE_SIZE;
-            const tileX   = Math.floor(fireSprite.x / size);
-            const tileY   = Math.floor(fireSprite.y / size);
-    
-            // extinguish from tileX‑2 up to tileX+2
-            for (let dx = -2; dx <= 2; dx++) {
-            const nx = tileX + dx;
-            if (nx >= 0 && nx < mapScene.map.width) {
-                const neighbor = mapScene.map.grid[tileY][nx];
-                if (neighbor && neighbor.sprite) {
-                mapScene.events.emit('extinguishFire', neighbor.sprite);
-                }
+            if (cooldown[4] == 0) {
+                setAirtanker(-1);
+                asset.useAirtanker(scene, x, y, fireSprite);
+                asset.startTimer(4, scene, c_airtanker, 750, 370);
+                coins += 500;
+            } else {
+                show_notification(scene, n_cooldown);
             }
-            }
-    
-            // update your coin display
-            bank.setText(`${coins}`);
-        });
-        // =========================================================
-    
+
+            scene.time.delayedCall(t_airtanker, () => {
+                scene.events.emit('extinguishFire', fireSprite);
+                bank.setText(`${coins}`);
+            })
+
         } else {
-        console.log("Sorry! You ran out!");
-        show_notification(scene, out_airtankers);
+            console.log("Sorry! You ran out!");
+
+            // Notification to player that they are out of airtankers
+            show_notification(scene, out_airtankers);
         }
     }
     if (activated_resource === "hotshot-crew") {
-    if (getHotshotCrew() > 0) {
-        if (cooldown[5] === 0) {
-        setHotshotCrew(-1);
-        asset.useHotshotCrew(scene, x, y, fireSprite);
-        asset.startTimer(5, scene, c_hotshotcrew, 750, 450);
-        coins += 300;
+        if (getHotshotCrew() > 0) {
+            if (cooldown[5] == 0) {
+                setHotshotCrew(-1);
+                asset.useHotshotCrew(scene, x, y, fireSprite);
+                asset.startTimer(5, scene, c_hotshotcrew, 750, 450);
+                coins += 300;
+            } else {
+                show_notification(scene, n_cooldown);
+            }
+
+            scene.time.delayedCall(t_hotshotcrew, () => {
+                scene.events.emit('extinguishFire', fireSprite);
+                bank.setText(`${coins}`);
+            })
+
         } else {
-        show_notification(scene, n_cooldown);
+            console.log("Sorry! You ran out!");
+
+            // Notification to player that they are out of hotshot crews
+            show_notification(scene, out_hotshots);
         }
-
-        // ==== DEFENSIVE LINE: carve through 5 tiles of unburnt terrain ====
-        scene.time.delayedCall(t_hotshotcrew, () => {
-        const mapScene = scene.scene.get('MapScene');
-        const size    = mapScene.TILE_SIZE;
-        const tileX   = Math.floor(fireSprite.x / size);
-        const tileY   = Math.floor(fireSprite.y / size);
-
-        for (let i = -2; i <= 2; i++) {
-            const nx = tileX + (dropDirection === 'horizontal' ? i : 0);
-            const ny = tileY + (dropDirection === 'vertical'   ? i : 0);
-
-            if (
-            nx >= 0 && nx < mapScene.map.width &&
-            ny >= 0 && ny < mapScene.map.height
-            ) {
-            const tile = mapScene.map.grid[ny][nx];
-            // only cut through normal, unburnt terrain
-            if (tile.burnStatus === 'unburned') {
-                tile.burnStatus    = 'firebreak';
-                tile.flammability  = 0;
-                // update its sprite to show a firebreak line
-                // (you can swap to a special texture or tint it)
-                tile.terrain       = 'burned-grass';  // or your custom 'firebreak' asset
-                mapScene.fireSpread.updateSprite(nx, ny);
-            }
-            }
-        }
-
-        bank.setText(`${coins}`);
-        });
-        // ==================================================================
-
-    } else {
-        console.log("Sorry! You ran out!");
-        show_notification(scene, out_hotshots);
     }
-    }
-
     if (activated_resource === "smokejumper") {
         if (getSmokejumpers() > 0) {
             if (cooldown[6] == 0) {


### PR DESCRIPTION
In this PR, the player can select and deselect assets in any order. If an asset is already active and clicked again, it is deselected. If a different asset is deselected, the previously activated asset is deactivated. Finally, the global "mode" variable is added for detecting whether the player is in deployment mode or not. This should help with future usability updates for mobile phones.

All updates are located in DeploymentClickEvents.js.